### PR TITLE
ci: aggiunto workflow GitHub Actions con test su più versioni Node.js e report coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+name: CI - Test e Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 21.x]
+
+    steps:
+    - name: Checkout del codice
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Installazione dipendenze
+      run: npm install
+
+    - name: Esecuzione test con coverage
+      run: npm run test:coverage
+
+    - name: Caricamento report coverage (solo per Node 20.x)
+      if: matrix.node-version == '20.x'
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage-report
+        path: coverage/lcov-report
+        retention-days: 5


### PR DESCRIPTION
**Scopo dell’introduzione della CI**

Questa Pull Request introduce un workflow CI tramite GitHub Actions, con l’obiettivo di automatizzare l'esecuzione dei test e generare un report di code coverage visualizzabile, a ogni push o pull request verso il branch `main`.

**Struttura del workflow**

- **Trigger utilizzati:** 
  - `push` su `main`
  - `pull_request` verso `main`
- **Job definito:**
  - `test`: eseguito su tre versioni attualmente supportate di Node.js (`18.x`, `20.x`, `21.x`) usando la `strategy.matrix`

 **Sequenza dei passaggi nel job**

1. **Checkout del codice** dal repository
2. **Setup di Node.js** con la versione della matrice
3. **Installazione delle dipendenze** con `npm install`
4. **Esecuzione dei test** con `npm run test:coverage`
5. **Caricamento del report coverage** solo per `node-version == 20.x` usando `actions/upload-artifact`, con `retention-days: 5`

 Il report HTML (`coverage/lcov-report`) sarà disponibile come artefatto scaricabile nella tab **Actions** > Dettagli del Job > **Artifacts**

 Questo approccio garantisce:
- Compatibilità multi-versione (LTS correnti)
- Automazione della qualità del codice
- Conservazione temporanea dei report senza spreco di storage
